### PR TITLE
[Task_two] add approval transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ so You can easily see what changes have been made.
 
 ## Homeworks
 - [x] Task 1 - [branch](https://github.com/DeagleGross/exonum/tree/task_one) - [Pull Request](https://github.com/DeagleGross/exonum/pull/1)
-- [ ] Task 2 - branch - Pull Request
+- [ ] Task 2 - [branch](https://github.com/DeagleGross/exonum/tree/task_two) - [Pull Request](https://github.com/DeagleGross/exonum/pull/2)
 - [ ] Task 3 - branch - Pull Request
 - [ ] Task 4 - branch - Pull Request
 ---

--- a/examples/cryptocurrency-advanced/backend/src/proto/service.proto
+++ b/examples/cryptocurrency-advanced/backend/src/proto/service.proto
@@ -40,6 +40,18 @@ message TxSendApprove {
   exonum.crypto.Hash approver = 4;
 }
 
+// Stands for Approval for some TxSendApproval transaction
+message TxApprove {
+  // Address of receiver's wallet.
+  exonum.crypto.Hash to = 1;
+  // Amount of currency to transfer.
+  uint64 amount = 2;
+  // Auxiliary number to guarantee non-idempotence of transactions.
+  uint64 seed = 3;
+  // Address of approver's wallet.
+  exonum.crypto.Hash approver = 4;
+}
+
 // Issue `amount` of the currency to the `wallet`.
 message Issue {
   // Issued amount of currency.

--- a/examples/cryptocurrency-advanced/backend/src/proto/service.proto
+++ b/examples/cryptocurrency-advanced/backend/src/proto/service.proto
@@ -42,14 +42,14 @@ message TxSendApprove {
 
 // Stands for Approval for some TxSendApproval transaction
 message TxApprove {
+  // Address of sender's wallet.
+  exonum.crypto.Hash from = 1;
   // Address of receiver's wallet.
-  exonum.crypto.Hash to = 1;
+  exonum.crypto.Hash to = 2;
   // Amount of currency to transfer.
-  uint64 amount = 2;
+  uint64 amount = 3;
   // Auxiliary number to guarantee non-idempotence of transactions.
-  uint64 seed = 3;
-  // Address of approver's wallet.
-  exonum.crypto.Hash approver = 4;
+  uint64 seed = 4;
 }
 
 // Issue `amount` of the currency to the `wallet`.

--- a/examples/cryptocurrency-advanced/backend/src/schema.rs
+++ b/examples/cryptocurrency-advanced/backend/src/schema.rs
@@ -26,6 +26,7 @@ use exonum_derive::{FromAccess, RequireArtifact};
 
 use crate::{wallet::Wallet, INITIAL_BALANCE};
 use crate::{transactions::TxSendApprove};
+use crate::{transactions::TxApprove};
 
 /// Database schema for the cryptocurrency.
 ///
@@ -46,7 +47,9 @@ pub struct Schema<T: Access> {
     /// Map of wallet keys to information about the corresponding account.
     pub wallets: RawProofMapIndex<T::Base, Address, Wallet>,
     /// Map of approval transactions hash to infromation about the corresponding approval transaction
-    pub approval_transactions: RawProofMapIndex<T::Base, Hash, TxSendApprove>
+    pub approval_transactions: RawProofMapIndex<T::Base, Hash, TxSendApprove>,
+    /// Map of approved tx_send_approved transactions
+    pub approved_transactions: RawProofMapIndex<T::Base, Hash, TxApprove>
 }
 
 impl<T: Access> SchemaImpl<T> {
@@ -66,13 +69,23 @@ where
 {
     /// Append new unapproved transaction record to db.
     /// 'wallet' - wallet of sender
-    pub fn create_approve_transaction(&mut self, wallet: Wallet, amount: u64, to: Address, approver: Address, tx_hash: Hash) {
+    pub fn create_send_approve_transaction(&mut self, wallet: Wallet, amount: u64, to: Address, approver: Address, tx_hash: Hash) {
         // Update freezed balance & save the history
         self.increase_wallet_freezed_balance(wallet, amount, tx_hash);
 
         // Save transaction in schema.approval_transactions
         let transaction = TxSendApprove::new(to, amount, approver);
         self.public.approval_transactions.put(&tx_hash, transaction);
+    }
+
+    /// Append new unapproved transaction record to db.
+    /// 'wallet' - wallet of sender
+    pub fn create_approve_transaction(&mut self, sender_wallet: Wallet, receiver_wallet: Wallet, amount: u64, tx_approve: TxApprove, tx_hash: Hash) {
+        // Update freezed balance & save the history
+        self.change_wallet_balances(sender_wallet, receiver_wallet, amount, tx_hash);
+
+        // Save transaction in schema.approval_transactions
+        self.public.approved_transactions.put(&tx_hash, tx_approve.clone());
     }
 
     /// Increases freezed balance of the wallet and append new record to its history.
@@ -89,6 +102,29 @@ where
         // storing in wallets-db
         let wallet_key = wallet.owner;
         self.public.wallets.put(&wallet_key, wallet);
+    }
+
+    /// Decreases freezed balance of the wallet and append new record to its history.
+    pub fn change_wallet_balances(&mut self, sender_wallet: Wallet, receiver_wallet: Wallet, amount: u64, transaction: Hash) {
+        // change sender_wallet state
+        let owner = sender_wallet.owner;
+        let mut history = self.wallet_history.get(&owner);
+        history.push(transaction);
+        let history_hash = history.object_hash();
+        let balance = sender_wallet.balance;
+        let balanced_wallet = sender_wallet.set_balance(balance - amount, &history_hash);
+        let freezed = balanced_wallet.freezed_balance;
+        let freezed_balanced_wallet = balanced_wallet.set_freezed_balance(freezed - amount, &history_hash);
+        self.public.wallets.put(&owner, freezed_balanced_wallet);
+
+        // change receiver_wallet state
+        let owner = receiver_wallet.owner;
+        let mut history = self.wallet_history.get(&owner);
+        history.push(transaction);
+        let history_hash = history.object_hash();
+        let balance = receiver_wallet.balance;
+        let balanced_wallet = receiver_wallet.set_balance(balance + amount, &history_hash);
+        self.public.wallets.put(&owner, balanced_wallet);
     }
 
     /// Increases balance of the wallet and append new record to its history.

--- a/examples/cryptocurrency-advanced/backend/src/transactions.rs
+++ b/examples/cryptocurrency-advanced/backend/src/transactions.rs
@@ -14,10 +14,7 @@
 
 //! Cryptocurrency transactions.
 
-use exonum::{
-    crypto::Hash,
-    runtime::{CallerAddress as Address, CommonError, ExecutionContext, ExecutionError},
-};
+use exonum::{ crypto::Hash, runtime::{CallerAddress as Address, CommonError, ExecutionContext, ExecutionError} };
 use exonum_derive::{exonum_interface, interface_method, BinaryValue, ExecutionFail, ObjectHash};
 use exonum_proto::ProtobufConvert;
 
@@ -68,12 +65,28 @@ pub struct Transfer {
     pub seed: u64
 }
 
-
 /// Information about transaction with approval stored in the database.
 #[derive(Clone, Debug)]
 #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::service::TxSendApprove", serde_pb_convert)]
 pub struct TxSendApprove {
+    /// Address of receiver's wallet.
+    pub to: Address,
+    /// Amount of currency to transfer.
+    pub amount: u64,
+    /// Auxiliary number to guarantee [non-idempotence][idempotence] of transactions.
+    ///
+    /// [idempotence]: https://en.wikipedia.org/wiki/Idempotence
+    pub seed: u64,
+    /// Address of approver person
+    pub approver: Address
+}
+
+/// Information about transaction with approval stored in the database.
+#[derive(Clone, Debug)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
+#[protobuf_convert(source = "proto::service::TxApprove", serde_pb_convert)]
+pub struct TxApprove {
     /// Address of receiver's wallet.
     pub to: Address,
     /// Amount of currency to transfer.
@@ -100,6 +113,22 @@ impl TxSendApprove {
             amount: amount,
             seed: rng.gen::<u64>(),
             approver: approver
+        }
+    }
+}
+
+impl TxApprove {
+    /// Creates a new approval transaction.
+    pub fn new(
+        tx_send: TxSendApprove
+    ) -> Self {
+        let mut rng = rand::thread_rng();
+
+        Self {
+            to: tx_send.to,
+            amount: tx_send.amount,
+            seed: rng.gen::<u64>(),
+            approver: tx_send.approver
         }
     }
 }
@@ -153,6 +182,9 @@ pub trait CryptocurrencyInterface<Ctx> {
     /// Transfer `amount` of the currency from one wallet to another with approval from third person.
     #[interface_method(id = 3)]
     fn tx_send_approve(&self, ctx: Ctx, arg: TxSendApprove) -> Self::Output;
+    /// Approve transaction tx_send_approve
+    #[interface_method(id = 4)]
+    fn tx_approve(&self, ctx: Ctx, arg: TxApprove) -> Self::Output;
 }
 
 impl CryptocurrencyInterface<ExecutionContext<'_>> for CryptocurrencyService {
@@ -183,6 +215,7 @@ impl CryptocurrencyInterface<ExecutionContext<'_>> for CryptocurrencyService {
         // Getting schema
         let (from, tx_hash) = extract_info(&context)?;
         let mut schema = SchemaImpl::new(context.service_data());
+        println!("tx_send_approve called with hash '{}'", tx_hash);
 
         let to = arg.to;
         let amount = arg.amount;
@@ -201,7 +234,35 @@ impl CryptocurrencyInterface<ExecutionContext<'_>> for CryptocurrencyService {
         if sender_wallet.balance - sender_wallet.freezed_balance < amount {
             Err(Error::InsufficientCurrencyAmount.into())
         } else {
-            schema.create_approve_transaction(sender_wallet, amount, to, arg.approver, tx_hash);
+            schema.create_send_approve_transaction(sender_wallet, amount, to, arg.approver, tx_hash);
+            println!("successfully finished tx_send_approve...");
+            Ok(())
+        }
+    }
+
+    fn tx_approve(&self, context: ExecutionContext<'_>, arg: TxApprove) -> Self::Output {
+        // Getting schema
+        let (from, tx_hash) = extract_info(&context)?;
+        let mut schema = SchemaImpl::new(context.service_data());
+        println!("tx_approve called with hash '{}'", tx_hash);
+
+        let to = arg.to;
+        let amount = arg.amount;
+
+        // Check sender's waller exists
+        let sender_wallet = schema.public.wallets.get(&from).ok_or(Error::SenderNotFound)?;
+        // Check receiver's waller exists
+        let receiver_wallet = schema.public.wallets.get(&to).ok_or(Error::ReceiverNotFound)?;
+
+        // logs
+        println!("sender_wallet: balance='{}'; freezed='{}'", sender_wallet.balance, sender_wallet.freezed_balance);
+        println!("receiver_wallet: balance='{}'; freezed='{}'", receiver_wallet.balance, receiver_wallet.freezed_balance);
+
+        // Check balance
+        if sender_wallet.balance - sender_wallet.freezed_balance >= 0 && amount <= sender_wallet.freezed_balance {
+            Err(Error::InsufficientCurrencyAmount.into())
+        } else {
+            schema.create_approve_transaction(sender_wallet, receiver_wallet, amount, arg.clone(), tx_hash);
             Ok(())
         }
     }

--- a/examples/cryptocurrency-advanced/backend/src/wallet.rs
+++ b/examples/cryptocurrency-advanced/backend/src/wallet.rs
@@ -67,7 +67,7 @@ impl Wallet {
             balance,
             self.freezed_balance,
             self.history_len + 1,
-            history_hash,
+            history_hash
         )
     }
 
@@ -79,7 +79,7 @@ impl Wallet {
             self.balance,
             freezed_balance,
             self.history_len + 1,
-            history_hash,
+            history_hash
         )
     }
 }


### PR DESCRIPTION
Add new transaction that is approving `tx_send_approve`.
Has to:
- subtract `freezed_balance` and `balance` from `sender_wallet`
- increase `balance` of `receiver_wallet`
